### PR TITLE
Feature/deploy fix

### DIFF
--- a/src/components/home/home-volunteer-list.tsx
+++ b/src/components/home/home-volunteer-list.tsx
@@ -37,8 +37,9 @@ const HomeVolunteerList = () => {
   }, []);
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [data, loading, error] =
-    useFetchData<VolunteerCardItem[]>("/v1/volunteers");
+  const [data, loading, error] = useFetchData<VolunteerCardItem[]>(
+    "/v1/volunteers?from=0&to=3&ordering=-id",
+  );
 
   return (
     <>
@@ -49,13 +50,9 @@ const HomeVolunteerList = () => {
             {error && <h2>최근 봉사활동이 존재하지 않아요 🥲</h2>}
             {data === undefined || loading
               ? null
-              : data
-                  .slice(0, Math.min(3, data.length))
-                  .map((value: VolunteerCardItem) => {
-                    return (
-                      <SmallVolunteerCard key={value.title} cardItem={value} />
-                    );
-                  })}
+              : data.map((value: VolunteerCardItem) => {
+                  return <SmallVolunteerCard key={value.id} cardItem={value} />;
+                })}
           </VolunteerCardContainer>
         </ListItemContainer>
       </HomeVolunteerListContainer>

--- a/src/components/home/home-volunteer-list.tsx
+++ b/src/components/home/home-volunteer-list.tsx
@@ -37,7 +37,8 @@ const HomeVolunteerList = () => {
   }, []);
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [data, loading, error] = useFetchData("/v1/volunteers");
+  const [data, loading, error] =
+    useFetchData<VolunteerCardItem[]>("/v1/volunteers");
 
   return (
     <>

--- a/src/components/volunteer-list.tsx
+++ b/src/components/volunteer-list.tsx
@@ -43,7 +43,7 @@ const VolunteerList = () => {
   const [ordering, setOrdering] = useState<OrderingType>("new");
   const location = useLocation();
 
-  const [data, loading, error, header] = useFetchData(
+  const [data, loading, error, header] = useFetchData<VolunteerCardItem[]>(
     `v1/volunteers?from=${(page - 1) * DATA_PER_PAGE}&to=${
       page * DATA_PER_PAGE
     }&ordering=${orderingOption[ordering]}`,

--- a/src/hooks/use-fetch-data.ts
+++ b/src/hooks/use-fetch-data.ts
@@ -1,12 +1,12 @@
 import { useEffect, useState } from "react";
 import Client from "../utils/client";
 
-const useFetchData = (
+const useFetchData = <T>(
   path: string,
   launch: boolean = true,
   config?: object,
-) => {
-  const [data, setData] = useState<any>();
+): [T | undefined, boolean, any, any] => {
+  const [data, setData] = useState<T>();
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<any>();
   const [header, setHeader] = useState<any>();


### PR DESCRIPTION
# Refactor List

## Refactor `useFetchData`.
- `map` or `slice` cannot be resolved in certain situations, so one declared the return type of the `useFetchdata`.
- Due to the above reason, one declared return types on components that use `useFetchData` to fetch data.

## Reflector fetch method in **HomeVolunteerComponent**.
- **From**: Fetch and slice default data
- **To**: Send a request with the limitation using `from`, `to`, and `ordering` params.
