### PR TITLE
Feature/fix milkdown view ctx

### DIFF
--- a/src/components/post/milkdown-editor/index.tsx
+++ b/src/components/post/milkdown-editor/index.tsx
@@ -33,7 +33,7 @@ const MilkdownEditor = ({ callback }: MilkdownEditorProps) => {
   return (
     <MilkdownContainer>
       <MilkdownEditorContainer>
-        <ReactEditor editor={editor} />
+        <ReactEditor editor={editor.editor} />
       </MilkdownEditorContainer>
     </MilkdownContainer>
   );


### PR DESCRIPTION
# Fix List

## Milkdown ReactEditor editor props type error
- By sending the value inside the `editor` variable, also called `editor`, one can fix the **Milkdown ReactEditor editor props type error**.